### PR TITLE
feat:iOS端增加自定义滑动操作耗时的方法，避免滑动过快触发的惯性滑动

### DIFF
--- a/src/main/java/org/cloud/sonic/driver/ios/IOSDriver.java
+++ b/src/main/java/org/cloud/sonic/driver/ios/IOSDriver.java
@@ -200,6 +200,20 @@ public class IOSDriver {
     }
 
     /**
+     * swipe position on screen with target time
+     *
+     * @param fromX
+     * @param fromY
+     * @param toX
+     * @param toY
+     * @param duration 滑动完成的时间，单位为毫秒
+     * @throws SonicRespException
+     */
+    public void swipe(double fromX, double fromY, double toX, double toY, double duration) throws SonicRespException {
+        wdaClient.swipe(fromX, fromY, toX, toY, duration);
+    }
+
+    /**
      * perform touch action.
      *
      * @param touchActions

--- a/src/main/java/org/cloud/sonic/driver/ios/service/WdaClient.java
+++ b/src/main/java/org/cloud/sonic/driver/ios/service/WdaClient.java
@@ -108,4 +108,6 @@ public interface WdaClient {
 
     //appium setting handler.
     void setAppiumSettings(JSONObject settings) throws SonicRespException;
+
+    void swipe(double fromX, double fromY, double toX, double toY, double duration) throws SonicRespException;
 }

--- a/src/main/java/org/cloud/sonic/driver/ios/service/impl/WdaClientImpl.java
+++ b/src/main/java/org/cloud/sonic/driver/ios/service/impl/WdaClientImpl.java
@@ -502,4 +502,30 @@ public class WdaClientImpl implements WdaClient {
             throw new SonicRespException(b.getErr().getMessage());
         }
     }
+
+    @Override
+    public void swipe(double fromX, double fromY, double toX, double toY, double duration) throws SonicRespException {
+        checkSessionId();
+        JSONObject data = new JSONObject();
+
+        double maxSwipeDistance = Math.max(Math.abs(toX - fromX), Math.abs(toY - fromY));
+        double velocity = maxSwipeDistance / duration * 1000;
+        // velocity 单位为像素/秒，这里做个限制，如果超过1000则滑动的过快，很容易触发fling行为
+        velocity = Math.min(velocity, 1000);
+        data.put("fromX", fromX);
+        data.put("fromY", fromY);
+        data.put("toX", toX);
+        data.put("toY", toY);
+        data.put("velocity", velocity);
+
+        BaseResp b = respHandler.getResp(HttpUtil.createPost(remoteUrl + "/session/" + sessionId + "/wda/pressAndDragWithVelocity")
+                .body(data.toJSONString()));
+        if (b.getErr() == null) {
+            logger.info("perform swipe %s successful.", data.toString());
+        } else {
+            logger.error("perform swipe %s failed.", data.toString());
+            throw new SonicRespException(b.getErr().getMessage());
+        }
+    }
+
 }

--- a/src/test/java/org/cloud/sonic/driver/ios/IOSDriverTest.java
+++ b/src/test/java/org/cloud/sonic/driver/ios/IOSDriverTest.java
@@ -144,7 +144,12 @@ public class IOSDriverTest {
     public void testSwipe() throws SonicRespException, InterruptedException {
         iosDriver.swipe(100, 256, 50, 256);
         Thread.sleep(500);
-        iosDriver.swipe(50, 256, 100, 256);
+        iosDriver.swipe(100, 600, 100, 200);
+    }
+
+    @Test
+    public void testSwipeWithTime() throws SonicRespException, InterruptedException {
+        iosDriver.swipe(100, 600, 100, 200, 2000);
     }
 
     @Test


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

现有的基于`/wda/touch/multi/perform`接口实现的滑动方法，实际完成滑动操作是在一瞬间完成的，当滑动距离过近时，会触发长列表的惯性滑动事件，可能导致目标元素被滚出屏幕外。查看wda的代码，可以基于`/wda/pressAndDragWithVelocity`实现指定滑动完成时间的效果。方法参数设置为毫秒，与安卓对齐。

自测iOS 16.3与iOS 15.3.1系统正常。


