### PR TITLE
fix:优化双端的findElementList逻辑，仅在查找到元素的时候退出while循环

### DIFF
--- a/src/main/java/org/cloud/sonic/driver/android/service/impl/UiaClientImpl.java
+++ b/src/main/java/org/cloud/sonic/driver/android/service/impl/UiaClientImpl.java
@@ -303,10 +303,11 @@ public class UiaClientImpl implements UiaClient {
                         androidElementList.add(new AndroidElementImpl(id, this));
                     } else {
                         logger.error("parse element id %s failed.", ele);
-                        continue;
                     }
                 }
-                break;
+                if (androidElementList.size() > 0) {
+                    break;
+                }
             } else {
                 logger.error("elements not found. retried %d times, retry in %d ms.", wait, intervalInit);
                 errMsg = b.getErr().getMessage();

--- a/src/main/java/org/cloud/sonic/driver/ios/service/impl/WdaClientImpl.java
+++ b/src/main/java/org/cloud/sonic/driver/ios/service/impl/WdaClientImpl.java
@@ -452,10 +452,11 @@ public class WdaClientImpl implements WdaClient {
                         iosElementList.add(new IOSElementImpl(id, this));
                     } else {
                         logger.error("parse element id %s failed.", ele);
-                        continue;
                     }
                 }
-                break;
+                if (iosElementList.size() > 0) {
+                    break;
+                }
             } else {
                 logger.error("elements not found. retried %d times, retry in %d ms.", wait, intervalInit);
                 errMsg = b.getErr().getMessage();


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

当前的findElementList存在一个问题，查找元素的网络请求成功，但是返回的list列表为空。当前的处理逻辑会退出循环，不再继续进行查找。

